### PR TITLE
Fix linux build

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -9,6 +9,7 @@ import { FuseV1Options, FuseVersion } from "@electron/fuses";
 
 const config: ForgeConfig = {
     packagerConfig: {
+        executableName: "electron-shadcn",
         asar: true,
     },
     rebuildConfig: {},


### PR DESCRIPTION
Hi @LuanRoger,

I get the following error if try to create a linux build without the executableName defined. I don't know if this is the best way to solve it but it works.

```
An unhandled rejection has occurred inside Forge:
Error: could not find the Electron app binary at [....]. You may need to re-bundle the app using Electron Packager's "executableName" option.
```

Reference: https://it-jm.tistory.com/187