### PR TITLE
Re-enable electron-squirrel-startup check

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,12 @@
 import { app, BrowserWindow } from "electron";
 import registerListeners from "./helpers/ipc/listeners-register";
-// "electron-squirrel-startup" seems broken when packaging with vite
-//import started from "electron-squirrel-startup";
 import path from "path";
 
 const inDevelopment = process.env.NODE_ENV === "development";
+
+if (require("electron-squirrel-startup")) {
+    app.quit();
+}
 
 function createWindow() {
     const preload = path.join(__dirname, "preload.js");

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,8 +4,12 @@ import path from "path";
 
 const inDevelopment = process.env.NODE_ENV === "development";
 
-if (require("electron-squirrel-startup")) {
-    app.quit();
+const platform = os.platform();
+
+if (platform === 'win32') {
+    if (require("electron-squirrel-startup")) {
+        app.quit();
+    }
 }
 
 function createWindow() {


### PR DESCRIPTION
Hello @LuanRoger,

I updated all the libraries, and when I tried again the project could be built on Linux without any issues.

~~It was probably something wrong on my side.~~
~~I think we can add those lines back.~~

I noticed that even though the project builds, I couldn't execute it on Linux without errors. I added a check for the OS and if it's windows, we very if electron-squirrel-startup is available, otherwise we simply ignore it.

Now the Linux application runs without any issues.