### PR TITLE
fix: add new options on componets.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,13 @@ To develop a Electron app, you probably will need some UI, test, formatter, styl
 
 > If you don't know some of these libraries or tools, I recommend you to check their documentation to understand how they work and how to use them.
 
+> [!WARNING]
+> Prefer to use the [`canary` release of `shadcn/ui`](https://ui.shadcn.com/docs/tailwind-v4) to avoid compatibility issues with React 19 and Tailwind v4.
+
+```bash
+npx shadcn@canary add button
+```
+
 ## Directory structure
 
 ```plaintext

--- a/components.json
+++ b/components.json
@@ -4,14 +4,17 @@
   "rsc": false,
   "tsx": true,
   "tailwind": {
-    "config": "tailwind.config.js",
-    "css": "@/styles/global.css",
+    "config": "",
+    "css": "src/styles/global.css",
     "baseColor": "slate",
     "cssVariables": true,
     "prefix": ""
   },
   "aliases": {
     "components": "@/components",
-    "utils": "@/lib/utils"
-  }
+    "utils": "@/utils/tailwind",
+    "ui": "@/components/ui",
+    "hooks": "@/hooks"
+  },
+  "iconLibrary": "lucide"
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -181,11 +181,8 @@
 }
 
 @layer base {
-  * {
-    @apply border-border outline-ring/50;
-  }
   body {
-    @apply bg-background text-foreground overflow-hidden;
+    @apply overflow-hidden;
   }
   .draglayer {
     @apply bg-background;
@@ -193,5 +190,14 @@
   }
   button {
     @apply cursor-pointer;
+  }
+}
+
+@layer base {
+  * {
+    @apply border-border outline-ring/50;
+  }
+  body {
+    @apply bg-background text-foreground;
   }
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,4 +1,4 @@
-@import 'tailwindcss';
+@import "tailwindcss";
 
 @plugin 'tailwindcss-animate';
 
@@ -111,7 +111,8 @@
     font-weight: 700;
     font-style: italic;
 
-    src: url("../assets/fonts/tomorrow/tomorrow-bold-italic.ttf") format("truetype");
+    src: url("../assets/fonts/tomorrow/tomorrow-bold-italic.ttf")
+      format("truetype");
   }
 }
 
@@ -181,10 +182,10 @@
 
 @layer base {
   * {
-    @apply m-0 border-border p-0;
+    @apply border-border outline-ring/50;
   }
   body {
-    @apply overflow-hidden bg-background text-foreground;
+    @apply bg-background text-foreground overflow-hidden;
   }
   .draglayer {
     @apply bg-background;


### PR DESCRIPTION
This pull request includes updates to the documentation and configuration for improved compatibility and code organization. The most important changes include adding a warning about using the `canary` release of `shadcn/ui`, updating the Tailwind CSS configuration, and reorganizing the global CSS styles.

Documentation update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R60-R66): Added a warning to prefer using the `canary` release of `shadcn/ui` to avoid compatibility issues with React 19 and Tailwind v4.

Configuration updates:

* [`components.json`](diffhunk://#diff-2c9eb56f775dd960fa3fb60253b2d30f21baae2e81f352e63a0984f129408016L7-R19): Updated Tailwind CSS configuration paths and added new aliases for `utils`, `ui`, and `hooks`. Also added the `iconLibrary` property.

CSS updates:

* [`src/styles/global.css`](diffhunk://#diff-03cc26efc9f06a95cd86aef185af462b72cc9d548a58177f8972837895f2de9eL1-R1): Changed the import statement for Tailwind CSS to use double quotes.
* [`src/styles/global.css`](diffhunk://#diff-03cc26efc9f06a95cd86aef185af462b72cc9d548a58177f8972837895f2de9eL114-R115): Reformatted the font-face `src` property to improve readability.
* [`src/styles/global.css`](diffhunk://#diff-03cc26efc9f06a95cd86aef185af462b72cc9d548a58177f8972837895f2de9eL183-R185): Moved the `@layer base` styles to ensure proper application of global styles, including reapplying some styles to the `body` element. [[1]](diffhunk://#diff-03cc26efc9f06a95cd86aef185af462b72cc9d548a58177f8972837895f2de9eL183-R185) [[2]](diffhunk://#diff-03cc26efc9f06a95cd86aef185af462b72cc9d548a58177f8972837895f2de9eR195-R203)