### PR TITLE
Add resolver for alias in electron main

### DIFF
--- a/vite.main.config.ts
+++ b/vite.main.config.ts
@@ -1,4 +1,11 @@
 import { defineConfig } from "vite";
+import path from "path";
 
 // https://vitejs.dev/config
-export default defineConfig({});
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    }
+  }
+});


### PR DESCRIPTION
This will enable the import alias with `@` inside electron, not just the renderer.

I used this in my personal project, but it would be awesome if the project had this by default!