### PR TITLE
Fix: Make command error

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -6,14 +6,13 @@ import { MakerRpm } from "@electron-forge/maker-rpm";
 import { VitePlugin } from "@electron-forge/plugin-vite";
 import { FusesPlugin } from "@electron-forge/plugin-fuses";
 import { FuseV1Options, FuseVersion } from "@electron/fuses";
-
-const name = 'electron-shadcn'
+import pkg from "./package.json";
 
 const config: ForgeConfig = {
   packagerConfig: {
+    executableName: pkg.name, 
+    name: pkg.productName, 
     asar: true,
-    name,
-    executableName: name
   },
   rebuildConfig: {},
   makers: [

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -7,9 +7,13 @@ import { VitePlugin } from "@electron-forge/plugin-vite";
 import { FusesPlugin } from "@electron-forge/plugin-fuses";
 import { FuseV1Options, FuseVersion } from "@electron/fuses";
 
+const name = 'electron-shadcn'
+
 const config: ForgeConfig = {
   packagerConfig: {
     asar: true,
+    name,
+    executableName: name
   },
   rebuildConfig: {},
   makers: [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,6 @@
     "composite": true,
     "declaration": true,
     "forceConsistentCasingInFileNames": true,
-    "resolvePackageJsonImports": true,
     "allowJs": false,
     "esModuleInterop": true,
     "noImplicitAny": true,
@@ -22,5 +21,5 @@
     "moduleResolution": "node",
     "resolveJsonModule": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "package.json", "forge.config.ts"]
 }


### PR DESCRIPTION
When trying to execute `yarn make` I got the following error

```
An unhandled rejection has occurred inside Forge:
Error: could not find the Electron app binary at "path/to/app". You may need to re-bundle the app using Electron Packager's "executableName" option.
```

This PR aims to address this problem.

After applying this to my personal project, I was able to create the deb and rpm files.