### PR TITLE
fix: resolve hydration error in NavigationMenu by leveraging asChild prop

### DIFF
--- a/src/components/template/NavigationMenu.tsx
+++ b/src/components/template/NavigationMenu.tsx
@@ -16,18 +16,14 @@ export default function NavigationMenu() {
     <NavigationMenuBase className="text-muted-foreground px-2">
       <NavigationMenuList>
         <NavigationMenuItem>
-          <Link to="/">
-            <NavigationMenuLink className={navigationMenuTriggerStyle()}>
-              {t("titleHomePage")}
-            </NavigationMenuLink>
-          </Link>
+          <NavigationMenuLink asChild className={navigationMenuTriggerStyle()}>
+            <Link to="/">{t("titleHomePage")}</Link>
+          </NavigationMenuLink>
         </NavigationMenuItem>
         <NavigationMenuItem>
-          <Link to="/second-page">
-            <NavigationMenuLink className={navigationMenuTriggerStyle()}>
-              {t("titleSecondPage")}
-            </NavigationMenuLink>
-          </Link>
+          <NavigationMenuLink asChild className={navigationMenuTriggerStyle()}>
+            <Link to="/second-page">{t("titleSecondPage")}</Link>
+          </NavigationMenuLink>
         </NavigationMenuItem>
       </NavigationMenuList>
     </NavigationMenuBase>


### PR DESCRIPTION
The previous implementation of NavigationMenu.tsx caused a hydration error due to invalid HTML nesting, where <a> elements (from Link components) were descendants of another <a> element created by NavigationMenuLink. This violated HTML standards and triggered a console error: "In HTML, <a> cannot be a descendant of <a>." 

To fix this, the code was updated to use the `asChild` prop on NavigationMenuLink, allowing it to wrap the Link component correctly without creating an additional <a> element. This ensures proper HTML structure, eliminates the hydration error, and maintains the intended navigation functionality.