### PR TITLE
chore(eslint): configure for React jsx-runtime

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -21,7 +21,7 @@ export default defineConfig([
   },
   { languageOptions: { globals: globals.browser } },
   pluginJs.configs.recommended,
-  pluginReact.configs.flat.recommended,
+  pluginReact.configs.flat["jsx-runtime"],
   reactHooks.configs.flat.recommended,
   eslintPluginPrettierRecommended,
   ...tseslint.configs.recommended,

--- a/src/components/DragWindowRegion.tsx
+++ b/src/components/DragWindowRegion.tsx
@@ -4,7 +4,7 @@ import {
   minimizeWindow,
 } from "@/helpers/window_helpers";
 import { isMacOS } from "@/utils/platform";
-import React, { type ReactNode } from "react";
+import { type ReactNode } from "react";
 
 interface DragWindowRegionProps {
   title?: ReactNode;

--- a/src/components/LangToggle.tsx
+++ b/src/components/LangToggle.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { ToggleGroup, ToggleGroupItem } from "./ui/toggle-group";
 import langs from "@/localization/langs";
 import { useTranslation } from "react-i18next";

--- a/src/components/ToggleTheme.tsx
+++ b/src/components/ToggleTheme.tsx
@@ -1,5 +1,4 @@
 import { Moon } from "lucide-react";
-import React from "react";
 import { Button } from "@/components/ui/button";
 import { toggleTheme } from "@/helpers/theme_helpers";
 

--- a/src/components/template/Footer.tsx
+++ b/src/components/template/Footer.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 export default function Footer() {
   return (
     <footer className="font-tomorrow text-muted-foreground inline-flex justify-between text-[0.7rem] uppercase">

--- a/src/components/template/InitialIcons.tsx
+++ b/src/components/template/InitialIcons.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { SiElectron, SiReact, SiVite } from "@icons-pack/react-simple-icons";
 
 export default function InitalIcons() {

--- a/src/components/template/NavigationMenu.tsx
+++ b/src/components/template/NavigationMenu.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Link } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
 import {

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import BaseLayout from "@/layouts/BaseLayout";
 import { Outlet, createRootRoute } from "@tanstack/react-router";
 /* import { TanStackRouterDevtools } from '@tanstack/react-router-devtools' */

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import ToggleTheme from "@/components/ToggleTheme";
 import { useTranslation } from "react-i18next";
 import LangToggle from "@/components/LangToggle";

--- a/src/routes/second.tsx
+++ b/src/routes/second.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import Footer from "@/components/template/Footer";
 import { useTranslation } from "react-i18next";
 import { createFileRoute } from "@tanstack/react-router";

--- a/src/tests/unit/ToggleTheme.test.tsx
+++ b/src/tests/unit/ToggleTheme.test.tsx
@@ -1,7 +1,6 @@
 import { render } from "@testing-library/react";
 import { test, expect } from "vitest";
 import ToggleTheme from "@/components/ToggleTheme";
-import React from "react";
 
 test("renders ToggleTheme", () => {
   const { getByRole } = render(<ToggleTheme />);


### PR DESCRIPTION
Updated ESLint configuration to use `pluginReact.configs.flat["jsx-runtime"]`. This enables React's new JSX transform, which automatically imports the necessary runtime functions, eliminating the need for `import React from 'react'` in component files. Redundant `React` imports were removed across the codebase to align with this configuration, cleaning up component files.