### PR TITLE
fix: broken documentation link

### DIFF
--- a/src/components/navigation-menu.tsx
+++ b/src/components/navigation-menu.tsx
@@ -27,7 +27,7 @@ export default function NavigationMenu() {
         </NavigationMenuItem>
         <NavigationMenuItem>
           <NavigationMenuLink asChild className={navigationMenuTriggerStyle()}>
-            <ExternalLink href="https://docs.luanroger.dev/electron-shadcn">
+            <ExternalLink href="https://docs.luanroger.dev/electron-shadcn/docs/overview">
               {t("documentation")}
             </ExternalLink>
           </NavigationMenuLink>


### PR DESCRIPTION
This pull request updates the documentation link in the navigation menu to point directly to the overview page, making it more specific and user-friendly.

* Navigation Menu Update:
  * Changed the `ExternalLink` in `NavigationMenu` to direct users to `https://docs.luanroger.dev/electron-shadcn/docs/overview` instead of the previous, less specific URL.